### PR TITLE
adding timing of processing batches, adding support for image documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-
-# Llava Captioner
+# Llama Captioner
 
 ## Description
 
-The Llava Captioner is a CLAMS app designed to generate textual descriptions for video frames. It uses the LLaVA-NeXT model with 4-bit quantization for generation. The app processes video documents with timeframe annotations. The app will run on the representative frame for a timeframe or the middle frame if the timeframe does not specify representative frames. 
+The Llama Captioner is a CLAMS app designed to generate textual descriptions for video frames using the LLaMA 3.2 model. It processes video documents with timeframe annotations and generates captions accordingly.
 
-For more information about LLaVA-NeXT see: [LLaVA-NeXT Blog Post](https://llava-vl.github.io/blog/2024-01-30-llava-next/)
+For more information about LLaMA 3.2 see: [LLaMA 3.2 Blog Post](https://llama-vl.github.io/blog/2024-01-30-llama-3.2/)
 
-For LLaVA license information see: [LLaVA Github Repo](https://github.com/haotian-liu/LLaVA#:~:text=Usage%20and%20License,laws%20and%20regulations.)
+For LLaMA license information see: [LLaMA Github Repo](https://github.com/haotian-liu/LLaMA#:~:text=Usage%20and%20License,laws%20and%20regulations.)
 
 ## User instruction
 

--- a/config/shot_captioning.yaml
+++ b/config/shot_captioning.yaml
@@ -1,6 +1,6 @@
 default_prompt: |
   [INST] <image>
-  Provide a detailed description of this video frame. Include information about the setting, people, objects, actions, colors, and any other significant visual elements. [/INST]
+  Provide a description of this video frame from a news broadcast. Ignore the watermark.[/INST]
 
 context_config:
   input_context: "timeframe"  # Options: "timeframe", "timepoint", "fixed_window"

--- a/config/slate_images.yaml
+++ b/config/slate_images.yaml
@@ -1,0 +1,6 @@
+default_prompt: |
+  [INST] <image>
+  Transcribe all dates in the image. Separate dates with a comma. [/INST]
+
+context_config:
+  input_context: "image"  # Options: "timeframe", "timepoint", "fixed_window", "image"

--- a/metadata.py
+++ b/metadata.py
@@ -32,6 +32,7 @@ def appmetadata() -> AppMetadata:
 
     # and then add I/O specifications: an app must have at least one input and one output
     metadata.add_input(DocumentTypes.VideoDocument)
+    metadata.add_input(DocumentTypes.ImageDocument)
     metadata.add_input(AnnotationTypes.TimeFrame)
     metadata.add_output(AnnotationTypes.Alignment)
     metadata.add_output(DocumentTypes.TextDocument)
@@ -59,6 +60,10 @@ def appmetadata() -> AppMetadata:
     metadata.add_parameter(
         name='modelVersion', type='string', default='3.2',
         description='Version of the LLaMA model to use.'
+    )
+    # add parameter for config file name
+    metadata.add_parameter(  #todo check this path 
+        name='config', type='string', default="config/default.yaml", description='Name of the config file to use.'
     )
     
     return metadata


### PR DESCRIPTION
This commit adds support for mmif's referencing image documents. This will be used for evaluating the transcribed slates dataset. It also adds some timing information for the calls of the llava model. These will be removed or changed to logging in a future release. 
